### PR TITLE
Fix signup keyboard scroll, floating navbar overlap, and photo-delete ordering

### DIFF
--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -10,7 +10,7 @@ import CircleFAB from "@/components/ui/CircleFAB";
 import EmptyState from "@/components/ui/EmptyState";
 import LoadingState from "@/components/ui/LoadingState";
 import { useExplore } from "@/hooks/useExplore";
-import { colors, radius, spacing, typography } from "@/src/constants/theme";
+import { colors, layout, radius, spacing, typography } from "@/src/constants/theme";
 import { Platform, Pressable, Text, View } from "react-native";
 
 // Dynamic imports for platform-specific map components
@@ -221,7 +221,7 @@ export default function ExploreScreen() {
         <Pressable
           style={{
             position: "absolute",
-            bottom: spacing.sm,
+            bottom: layout.navBarClearance,
             left: spacing.sm,
             backgroundColor: "rgba(255, 255, 255, 0.7)",
             paddingHorizontal: spacing.sm - 2,
@@ -238,7 +238,7 @@ export default function ExploreScreen() {
           <View
             style={{
               position: "absolute",
-              bottom: spacing.giant + spacing.huge + spacing.md,
+              bottom: layout.navBarClearance + spacing.huge + spacing.md,
               right: spacing.lg,
               backgroundColor: "rgba(0, 0, 0, 0.8)",
               paddingHorizontal: spacing.md,
@@ -257,7 +257,7 @@ export default function ExploreScreen() {
         )}
 
         {/* Refresh button */}
-        <CircleFAB onPress={fetchListings} style={{ position: "absolute", bottom: spacing.giant, right: spacing.lg }}>
+        <CircleFAB onPress={fetchListings} style={{ position: "absolute", bottom: layout.navBarClearance, right: spacing.lg }}>
           <Text style={{ fontSize: typography.size.xxl, color: colors.black }}>↻</Text>
         </CircleFAB>
       </View>

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -9,7 +9,7 @@ import PriceRangeModal from "@/components/ui/PriceRangeModal";
 import EmptyState from "@/components/ui/EmptyState";
 import PriceFilterPill from "@/components/ui/PriceFilterPill";
 import { useHomeListings } from "@/hooks/useHomeListings";
-import { spacing } from "@/src/constants/theme";
+import { layout, spacing } from "@/src/constants/theme";
 
 export default function HomeScreen() {
   const {
@@ -70,7 +70,7 @@ export default function HomeScreen() {
           data={listings}
           keyExtractor={(listing) => listing.id}
           renderItem={({ item }) => <ListingCard listing={item} />}
-          contentContainerStyle={{ paddingBottom: spacing.massive }}
+          contentContainerStyle={{ paddingBottom: layout.navBarClearance }}
           showsVerticalScrollIndicator={false}
           ListEmptyComponent={<EmptyState title="No listings found." offsetTop={spacing.giant} />}
         />

--- a/app/(tabs)/new_post.tsx
+++ b/app/(tabs)/new_post.tsx
@@ -10,6 +10,7 @@ import Stack from "@/components/ui/Stack";
 import TabSelector from "@/components/ui/TabSelector";
 import ListingFormFields from "@/components/listings/ListingFormFields";
 import { useNewPost } from "@/hooks/useNewPost";
+import { layout } from "@/src/constants/theme";
 
 export default function NewPostScreen() {
   const {
@@ -163,7 +164,7 @@ export default function NewPostScreen() {
   if (!role) return <LoadingState label="Could not determine your role. Please re-login." showSpinner={false} />;
 
   return (
-    <Screen scrollable>
+    <Screen scrollable contentContainerStyle={{ paddingBottom: layout.navBarClearance }}>
       {role === "landlord" ? landlordForm() : studentForm()}
     </Screen>
   );

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -10,7 +10,7 @@ import DetailRow from "@/components/ui/DetailRow";
 import Avatar from "@/components/ui/Avatar";
 import Card from "@/components/ui/Card";
 import CardSectionHeader from "@/components/ui/CardSectionHeader";
-import { colors, radius, spacing, typography } from "@/src/constants/theme";
+import { colors, layout, radius, spacing, typography } from "@/src/constants/theme";
 
 export default function ProfileScreen() {
   const router = useRouter();
@@ -36,7 +36,7 @@ export default function ProfileScreen() {
         contentContainerStyle={{
           paddingHorizontal: spacing.xl,
           paddingTop: spacing.xxl + 4,
-          paddingBottom: spacing.xxxxl,
+          paddingBottom: layout.navBarClearance,
           gap: spacing.md + 2,
         }}
         showsVerticalScrollIndicator={false}

--- a/app/(tabs)/saved.tsx
+++ b/app/(tabs)/saved.tsx
@@ -10,7 +10,7 @@ import IconCircle from "@/components/ui/IconCircle";
 import TabPageHeader from "@/components/ui/TabPageHeader";
 import FilterPills from "@/components/ui/FilterPills";
 import PostPreviewCard from "@/components/listings/PostPreviewCard";
-import { colors, radius, spacing, typography } from "@/src/constants/theme";
+import { colors, layout, radius, spacing, typography } from "@/src/constants/theme";
 
 export default function SavedScreen() {
   const {
@@ -80,7 +80,7 @@ export default function SavedScreen() {
                   onUnsave={() => toggleSaveListing(item.id)}
                 />
               )}
-              contentContainerStyle={{ paddingBottom: spacing.massive, gap: spacing.sm - 2 }}
+              contentContainerStyle={{ paddingBottom: layout.navBarClearance, gap: spacing.sm - 2 }}
               showsVerticalScrollIndicator={false}
             />
           )
@@ -118,7 +118,7 @@ export default function SavedScreen() {
                   }
                 />
               )}
-              contentContainerStyle={{ paddingBottom: spacing.massive, gap: spacing.sm - 2 }}
+              contentContainerStyle={{ paddingBottom: layout.navBarClearance, gap: spacing.sm - 2 }}
               showsVerticalScrollIndicator={false}
             />
           )

--- a/app/(tabs)/users.tsx
+++ b/app/(tabs)/users.tsx
@@ -9,7 +9,7 @@ import TabPageHeader from "@/components/ui/TabPageHeader";
 import IconCircle from "@/components/ui/IconCircle";
 import FilterPills from "@/components/ui/FilterPills";
 import PostPreviewCard from "@/components/listings/PostPreviewCard";
-import { colors, radius, spacing } from "@/src/constants/theme";
+import { colors, layout, radius, spacing } from "@/src/constants/theme";
 
 export default function UsersScreen() {
   const {
@@ -90,7 +90,7 @@ export default function UsersScreen() {
                 />
               );
             }}
-            contentContainerStyle={{ paddingBottom: spacing.massive, gap: spacing.sm - 2 }}
+            contentContainerStyle={{ paddingBottom: layout.navBarClearance, gap: spacing.sm - 2 }}
             showsVerticalScrollIndicator={false}
           />
         )}

--- a/components/navigation-bar.tsx
+++ b/components/navigation-bar.tsx
@@ -5,7 +5,7 @@ import Profile from "@/assets/images/nav_bar/profile.svg";
 import Users from "@/assets/images/nav_bar/users_icon.svg";
 import { usePathname, useRouter } from "expo-router";
 import { Platform, Pressable, StyleSheet, Text, View } from "react-native";
-import { colors, spacing, typography } from "@/src/constants/theme";
+import { colors, layout, spacing, typography } from "@/src/constants/theme";
 
 export function NavigationBar() {
   const router = useRouter();
@@ -272,11 +272,11 @@ const styles = StyleSheet.create({
   // Mobile styles
   mobileContainer: {
     position: "absolute",
-    bottom: spacing.xl,
+    bottom: layout.navBarBottomOffset,
     alignSelf: "center",
     width: "90%",
     maxWidth: 480,
-    height: 70,
+    height: layout.navBarHeight,
     backgroundColor: colors.white,
     flexDirection: "row",
     justifyContent: "space-around",

--- a/components/ui/Screen.tsx
+++ b/components/ui/Screen.tsx
@@ -1,5 +1,5 @@
 import { StatusBar } from "expo-status-bar";
-import { ScrollView, StyleSheet, View, ViewStyle } from "react-native";
+import { KeyboardAvoidingView, Platform, ScrollView, StyleSheet, View, ViewStyle } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { colors, spacing } from "@/src/constants/theme";
 
@@ -24,17 +24,23 @@ export default function Screen({
     return (
       <SafeAreaView style={[styles.container, style]}>
         <StatusBar style="light" />
-        <ScrollView
-          showsVerticalScrollIndicator={false}
-          keyboardShouldPersistTaps="handled"
-          contentContainerStyle={[
-            hPad,
-            styles.scrollBase,
-            contentContainerStyle,
-          ]}
+        <KeyboardAvoidingView
+          style={styles.inner}
+          behavior={Platform.OS === "ios" ? "padding" : undefined}
+          keyboardVerticalOffset={Platform.OS === "ios" ? 0 : undefined}
         >
-          {children}
-        </ScrollView>
+          <ScrollView
+            showsVerticalScrollIndicator={false}
+            keyboardShouldPersistTaps="handled"
+            contentContainerStyle={[
+              hPad,
+              styles.scrollBase,
+              contentContainerStyle,
+            ]}
+          >
+            {children}
+          </ScrollView>
+        </KeyboardAvoidingView>
       </SafeAreaView>
     );
   }

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -105,3 +105,12 @@ export const typography = {
     extrabold: "800" as const,
   },
 } as const;
+
+// The mobile bottom nav is a floating pill (`position: "absolute"`), so it
+// never reserves layout space on its own — every tab screen's scrollable
+// content must add its own bottom padding to clear it.
+export const layout = {
+  navBarHeight: 70,
+  navBarBottomOffset: spacing.xl,
+  navBarClearance: 70 + spacing.xl + spacing.lg,
+} as const;

--- a/src/services/listing.service.ts
+++ b/src/services/listing.service.ts
@@ -74,14 +74,17 @@ export class ListingService {
     try {
       // Get the listing first to find photos to delete
       const listing = await this.getListingById(listingId);
-      
-      // Delete the listing (the DB cascade handles saved_listings)
-      await apiClient.delete(`/api/listings/${listingId}`);
 
-      // Delete photos from backend storage
+      // Delete photos from backend storage first: the backend verifies
+      // ownership by checking the photo is still referenced by one of the
+      // caller's own listings, which only works while the listing row
+      // still exists.
       if (listing?.photo_urls?.length) {
         await this.deleteListingPhotos(listing.photo_urls);
       }
+
+      // Delete the listing (the DB cascade handles saved_listings)
+      await apiClient.delete(`/api/listings/${listingId}`);
 
       return { success: true };
     } catch (error: any) {


### PR DESCRIPTION
## Summary
- Fix scrollable screens (signup, login, edit-profile, listing edit, etc.) not reaching bottom content when the keyboard is open — `Screen`'s scrollable mode had no `KeyboardAvoidingView`, so iOS never resized the scroll area.
- Fix the floating bottom nav bar overlapping content on every tab screen — it's `position: absolute` and reserves no layout space, but screens' bottom padding was less than the bar's real footprint. Added a shared `layout.navBarClearance` token and applied it across all 6 tab screens plus explore's floating buttons/attribution.
- Reorder `deleteListing` to delete photos before deleting the listing row — companion change for the backend's new storage-deletion ownership check (see campusnest-backend PR), which needs the listing to still exist to verify ownership.

## Test plan
- [x] `tsc --noEmit`, `expo lint`, `jest` all pass
- [x] `expo export --platform web` — all 27 routes bundle with zero errors
- [ ] Manual on-device check: signup form scrolls fully with keyboard open
- [ ] Manual on-device check: nav bar no longer overlaps list/scroll content on any tab